### PR TITLE
Fix Hebrew subtitle corruption when syncing Windows-1255 files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ Sync is a four-stage pipeline. Only Stage 2 will ever involve AI, and it is not 
 | `src/sync/types.ts` | `SubtitleEntry`, `TimeSpan`, `Segment`, `TimeWarp` interfaces |
 | `src/sync/subtitleParser.ts` | `parseSrt()` |
 | `src/sync/subtitleWriter.ts` | `writeSrt()`, `formatTimestamp()` |
+| `src/sync/subtitleEncoding.ts` | `decodeSubtitle()` — UTF-8 when the bytes are valid UTF-8, else Windows-1255; `encodeSubtitle()` — always UTF-8 with BOM. Every subtitle read and write in the syncer goes through these, never `readFileSync(..., "utf-8")` |
 | `src/sync/mkvExtractor.ts` | `MkvExtractor` — runs `mkvmerge -J` and `mkvextract`. `findSubtitleTrack(path, languages)` is language-parameterised with ISO 639-2/639-3/BCP-47 alias matching; used for both embedded Hebrew detection and reference extraction |
 | `src/sync/referenceSourceFinder.ts` | Given the target `.srt`, derives the stem, locates the video, and resolves a reference — embedded track first, then sidecar; French before English |
 | `src/sync/syncGates.ts` | `GateFailure` — the reasons Flow B can stop before writing |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Sync is a four-stage pipeline. Only Stage 2 will ever involve AI, and it is not 
 | `src/sync/types.ts` | `SubtitleEntry`, `TimeSpan`, `Segment`, `TimeWarp` interfaces |
 | `src/sync/subtitleParser.ts` | `parseSrt()` |
 | `src/sync/subtitleWriter.ts` | `writeSrt()`, `formatTimestamp()` |
-| `src/sync/subtitleEncoding.ts` | `decodeSubtitle()` — UTF-8 when the bytes are valid UTF-8, else Windows-1255; `encodeSubtitle()` — always UTF-8 with BOM. Every subtitle read and write in the syncer goes through these, never `readFileSync(..., "utf-8")` |
+| `src/sync/subtitleEncoding.ts` | `decodeSubtitle()` — UTF-8 when the bytes are valid UTF-8; otherwise lenient UTF-8 or Windows-1255, whichever yields more Hebrew letters; `encodeSubtitle()` — always UTF-8 with BOM. Every subtitle read and write in the syncer goes through these, never `readFileSync(..., "utf-8")` |
 | `src/sync/mkvExtractor.ts` | `MkvExtractor` — runs `mkvmerge -J` and `mkvextract`. `findSubtitleTrack(path, languages)` is language-parameterised with ISO 639-2/639-3/BCP-47 alias matching; used for both embedded Hebrew detection and reference extraction |
 | `src/sync/referenceSourceFinder.ts` | Given the target `.srt`, derives the stem, locates the video, and resolves a reference — embedded track first, then sidecar; French before English |
 | `src/sync/syncGates.ts` | `GateFailure` — the reasons Flow B can stop before writing |

--- a/src/sync/subtitleEncoding.ts
+++ b/src/sync/subtitleEncoding.ts
@@ -1,0 +1,30 @@
+/**
+ * Bytes <-> text for subtitle files.
+ *
+ * Many Hebrew subtitles are still Windows-1255, not UTF-8. Reading one as UTF-8 does not
+ * throw: Node replaces every Hebrew byte with U+FFFD, and the writer then saves that loss
+ * over the user's file. So a file is decoded as UTF-8 only when it really is UTF-8.
+ *
+ * Output is always UTF-8 with a BOM. Node cannot encode Windows-1255, and the BOM stops
+ * players from guessing a legacy codepage for the file.
+ */
+
+const UTF8_BOM = Buffer.from([0xEF, 0xBB, 0xBF]);
+
+/** Language-specific fallback for bytes that are not valid UTF-8. */
+const LEGACY_ENCODING = "windows-1255";
+
+export function decodeSubtitle(bytes: Buffer): string {
+    // TextDecoder consumes a leading BOM, which parseSrt would otherwise read as part of
+    // the first index and drop that entry.
+    try {
+        return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    }
+    catch {
+        return new TextDecoder(LEGACY_ENCODING).decode(bytes);
+    }
+}
+
+export function encodeSubtitle(text: string): Buffer {
+    return Buffer.concat([UTF8_BOM, Buffer.from(text, "utf-8")]);
+}

--- a/src/sync/subtitleEncoding.ts
+++ b/src/sync/subtitleEncoding.ts
@@ -14,6 +14,8 @@ const UTF8_BOM = Buffer.from([0xEF, 0xBB, 0xBF]);
 /** Language-specific fallback for bytes that are not valid UTF-8. */
 const LEGACY_ENCODING = "windows-1255";
 
+const HEBREW_LETTER = /[א-ת]/g;
+
 export function decodeSubtitle(bytes: Buffer): string {
     // TextDecoder consumes a leading BOM, which parseSrt would otherwise read as part of
     // the first index and drop that entry.
@@ -21,8 +23,19 @@ export function decodeSubtitle(bytes: Buffer): string {
         return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
     }
     catch {
-        return new TextDecoder(LEGACY_ENCODING).decode(bytes);
+        // Not strictly UTF-8. It may still be a UTF-8 file with one stray legacy byte, and
+        // decoding that as Windows-1255 garbles every Hebrew line to save one byte. The
+        // target is always Hebrew, so the decoding that yields more Hebrew letters is the
+        // right one. Counting U+FFFD cannot tell them apart: Windows-1255 maps nearly every
+        // byte to some character, so it produces none either way.
+        const utf8 = new TextDecoder("utf-8").decode(bytes);
+        const legacy = new TextDecoder(LEGACY_ENCODING).decode(bytes);
+        return countHebrewLetters(legacy) > countHebrewLetters(utf8) ? legacy : utf8;
     }
+}
+
+function countHebrewLetters(text: string): number {
+    return text.split(HEBREW_LETTER).length - 1;
 }
 
 export function encodeSubtitle(text: string): Buffer {

--- a/src/sync/subtitleSyncer.ts
+++ b/src/sync/subtitleSyncer.ts
@@ -12,6 +12,7 @@ import type { NotifierInterface } from "~src/notifier";
 import { NotificationType } from "~src/notifier";
 import type { ReferenceSource, ReferenceSourceFinderInterface } from "~src/sync/referenceSourceFinder";
 import { parseSrt } from "~src/sync/subtitleParser";
+import { decodeSubtitle, encodeSubtitle } from "~src/sync/subtitleEncoding";
 import { writeSrt } from "~src/sync/subtitleWriter";
 import { timeWarp } from "~src/sync/timeWarp";
 import type { TimeWarpOptions } from "~src/sync/timeWarp";
@@ -70,7 +71,7 @@ export class SubtitleSyncer {
             const corrected = retime(target, warp);
 
             this.backup(targetSrtPath);
-            fs.writeFileSync(targetSrtPath, writeSrt(corrected), "utf-8");
+            fs.writeFileSync(targetSrtPath, encodeSubtitle(writeSrt(corrected)));
 
             this.report(targetSrtPath, warp);
             return { ok: true, warp };
@@ -119,7 +120,7 @@ export class SubtitleSyncer {
 
     private readEntries(srtPath: string, label: string): SubtitleEntry[] | null {
         try {
-            return parseSrt(fs.readFileSync(srtPath, "utf-8"));
+            return parseSrt(decodeSubtitle(fs.readFileSync(srtPath)));
         }
         catch (e) {
             this.logger.warn(`Sync: Failed to read ${label} ${srtPath}: ${errorText(e)}`);

--- a/test/sync/cases.test.ts
+++ b/test/sync/cases.test.ts
@@ -14,6 +14,7 @@ import { timeWarp } from "~src/sync/timeWarp";
 import { retime } from "~src/sync/retimer";
 import { SubtitleSyncer } from "~src/sync/subtitleSyncer";
 import { parseSrt } from "~src/sync/subtitleParser";
+import { decodeSubtitle } from "~src/sync/subtitleEncoding";
 import type { SubtitleEntry, TimeSpan } from "~src/sync/types";
 import type { ReferenceSourceFinderInterface } from "~src/sync/referenceSourceFinder";
 import { MockLogger, MockNotifier } from "~test/mocks";
@@ -224,7 +225,7 @@ describe("sync fixtures — end to end through SubtitleSyncer", () => {
     it("writes the corrected subtitle and a .bak, leaving the fixtures untouched", async () => {
         const name = caseNames[0];
         copy = copyCaseToTmp(name);
-        const original = fs.readFileSync(copy.targetPath, "utf-8");
+        const original = fs.readFileSync(copy.targetPath);
 
         const finder: ReferenceSourceFinderInterface = {
             find: jest.fn().mockResolvedValue({ source: { srtPath: copy.referencePath, language: "en", origin: "sidecar" } })
@@ -234,10 +235,10 @@ describe("sync fixtures — end to end through SubtitleSyncer", () => {
         const outcome = await new SubtitleSyncer(finder, logger, notifier).sync(copy.targetPath);
 
         expect(outcome.ok).toBe(true);
-        expect(fs.readFileSync(`${copy.targetPath}.bak`, "utf-8")).toBe(original);
+        expect(fs.readFileSync(`${copy.targetPath}.bak`).equals(original)).toBe(true);
 
-        const corrected = parseSrt(fs.readFileSync(copy.targetPath, "utf-8"));
-        const before = parseSrt(original);
+        const corrected = parseSrt(decodeSubtitle(fs.readFileSync(copy.targetPath)));
+        const before = parseSrt(decodeSubtitle(original));
         expect(corrected).toHaveLength(before.length);
         expect(corrected.map((e) => e.text)).toEqual(before.map((e) => e.text));
         expect(corrected[0].start).not.toBe(before[0].start);

--- a/test/sync/fixtures.ts
+++ b/test/sync/fixtures.ts
@@ -15,6 +15,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { parseSrt } from "~src/sync/subtitleParser";
+import { decodeSubtitle } from "~src/sync/subtitleEncoding";
 import { isExistSync } from "~src/fileUtils";
 import type { SubtitleEntry } from "~src/sync/types";
 
@@ -63,8 +64,8 @@ export function loadCase(name: string): SyncCase {
         targetPath,
         referencePath,
         referenceLanguage: referenceFile.endsWith(".fr.srt") || referenceFile.endsWith(".fra.srt") || referenceFile.endsWith(".fre.srt") ? "fr" : "en",
-        target: parseSrt(readUtf8(targetPath)),
-        reference: parseSrt(readUtf8(referencePath))
+        target: parseSrt(readSubtitle(targetPath)),
+        reference: parseSrt(readSubtitle(referencePath))
     };
 }
 
@@ -110,10 +111,9 @@ function findBySuffix(files: string[], suffixes: string[]): string | undefined {
     return undefined;
 }
 
-function readUtf8(file: string): string {
-    // Some subtitle downloads carry a BOM; parseSrt would read it as part of the first index.
-    const text = fs.readFileSync(file, "utf-8");
-    return text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
+function readSubtitle(file: string): string {
+    // Same decoding as the syncer: the Hebrew fixtures are Windows-1255, not UTF-8.
+    return decodeSubtitle(fs.readFileSync(file));
 }
 
 function walk(dir: string, visit: (file: string) => void): void {

--- a/test/sync/subtitleEncoding.test.ts
+++ b/test/sync/subtitleEncoding.test.ts
@@ -1,0 +1,31 @@
+import { decodeSubtitle, encodeSubtitle } from "~src/sync/subtitleEncoding";
+import { toWindows1255 } from "~test/sync/windows1255";
+
+const HEBREW = "1\r\n00:00:40,541 --> 00:00:44,503\r\nג'ודי דייויס\r\n";
+
+describe("decodeSubtitle", () => {
+    it("decodes a Windows-1255 file as Hebrew", () => {
+        expect(decodeSubtitle(toWindows1255(HEBREW))).toBe(HEBREW);
+    });
+
+    it("decodes a UTF-8 file without a BOM", () => {
+        expect(decodeSubtitle(Buffer.from(HEBREW, "utf-8"))).toBe(HEBREW);
+    });
+
+    it("strips a UTF-8 BOM, which parseSrt would read as part of the first index", () => {
+        const bytes = Buffer.concat([Buffer.from([0xEF, 0xBB, 0xBF]), Buffer.from(HEBREW, "utf-8")]);
+        expect(decodeSubtitle(bytes)).toBe(HEBREW);
+    });
+});
+
+describe("encodeSubtitle", () => {
+    it("writes UTF-8 with a BOM, so players do not guess a legacy codepage", () => {
+        const bytes = encodeSubtitle(HEBREW);
+        expect([...bytes.subarray(0, 3)]).toEqual([0xEF, 0xBB, 0xBF]);
+        expect(bytes.subarray(3).toString("utf-8")).toBe(HEBREW);
+    });
+
+    it("round-trips through decodeSubtitle", () => {
+        expect(decodeSubtitle(encodeSubtitle(HEBREW))).toBe(HEBREW);
+    });
+});

--- a/test/sync/subtitleEncoding.test.ts
+++ b/test/sync/subtitleEncoding.test.ts
@@ -12,6 +12,12 @@ describe("decodeSubtitle", () => {
         expect(decodeSubtitle(Buffer.from(HEBREW, "utf-8"))).toBe(HEBREW);
     });
 
+    it("keeps a UTF-8 file as UTF-8 when one stray legacy byte breaks strict decoding", () => {
+        // Decoding the whole file as Windows-1255 would garble every Hebrew line to lose one byte.
+        const bytes = Buffer.concat([Buffer.from(HEBREW, "utf-8"), Buffer.from([0xE9, 0x0D, 0x0A])]);
+        expect(decodeSubtitle(bytes)).toBe(`${HEBREW}�\r\n`);
+    });
+
     it("strips a UTF-8 BOM, which parseSrt would read as part of the first index", () => {
         const bytes = Buffer.concat([Buffer.from([0xEF, 0xBB, 0xBF]), Buffer.from(HEBREW, "utf-8")]);
         expect(decodeSubtitle(bytes)).toBe(HEBREW);

--- a/test/sync/subtitleSyncer.test.ts
+++ b/test/sync/subtitleSyncer.test.ts
@@ -6,6 +6,8 @@ import { GateFailure } from "~src/sync/syncGates";
 import type { ReferenceSourceFinderInterface, ReferenceSource } from "~src/sync/referenceSourceFinder";
 import { parseSrt } from "~src/sync/subtitleParser";
 import { writeSrt } from "~src/sync/subtitleWriter";
+import { decodeSubtitle } from "~src/sync/subtitleEncoding";
+import { toWindows1255 } from "~test/sync/windows1255";
 import type { SubtitleEntry } from "~src/sync/types";
 import { MockLogger, MockNotifier } from "~test/mocks";
 import { NotificationType } from "~src/notifier";
@@ -155,6 +157,24 @@ describe("SubtitleSyncer — successful sync", () => {
         const corrected = parseSrt(fs.readFileSync(target, "utf-8"));
         expect(corrected).toHaveLength(original.length);
         expect(corrected.map((e) => e.text)).toEqual(original.map((e) => e.text));
+    });
+
+    it("keeps Hebrew text when the target is Windows-1255", async () => {
+        // A real Windows-1255 file came back with every Hebrew letter replaced by U+FFFD.
+        const reference = makeEntries(40);
+        const hebrew = makeEntries(40, 2500).map((entry) => ({ ...entry, text: `שורה ${entry.index}` }));
+        const target = path.join(tmpDir, "Movie.heb.srt");
+        fs.writeFileSync(target, toWindows1255(writeSrt(hebrew).replace(/\n/g, "\r\n")));
+        const refPath = write("Movie.fr.srt", reference);
+
+        await new SubtitleSyncer(
+            finderReturning({ srtPath: refPath, language: "fr", origin: "sidecar", dispose: () => undefined }),
+            logger,
+            makeNotifier()
+        ).sync(target);
+
+        const corrected = parseSrt(decodeSubtitle(fs.readFileSync(target)));
+        expect(corrected.map((e) => e.text)).toEqual(hebrew.map((e) => e.text));
     });
 
     it("deletes an extracted reference when it is done", async () => {

--- a/test/sync/windows1255.ts
+++ b/test/sync/windows1255.ts
@@ -1,0 +1,17 @@
+/**
+ * Encode Hebrew text as Windows-1255 for tests. Node can only encode UTF-8, and many
+ * Hebrew subtitles in the wild are still Windows-1255, so tests build those bytes here.
+ * Covers ASCII and the 27 Hebrew letters, which is all the tests need.
+ */
+export function toWindows1255(text: string): Buffer {
+    return Buffer.from([...text].map((char) => {
+        const code = char.codePointAt(0);
+        if (code < 0x80) {
+            return code;
+        }
+        if (code >= 0x05D0 && code <= 0x05EA) {
+            return code - 0x05D0 + 0xE0;
+        }
+        throw new Error(`toWindows1255: no mapping for U+${code.toString(16)}`);
+    }));
+}


### PR DESCRIPTION
* Add subtitleEncoding.ts with decodeSubtitle and encodeSubtitle for the sync pipeline.
* Fall back to Windows-1255 in decodeSubtitle when bytes are not valid UTF-8. A silent UTF-8 read turned every Hebrew byte into U+FFFD. The syncer then wrote that loss back to the user's file.
* Write all subtitle output as UTF-8 with a BOM in encodeSubtitle. Node cannot encode Windows-1255. The BOM stops players from guessing a legacy codepage.
* Update SubtitleSyncer to read and write subtitles through decodeSubtitle and encodeSubtitle.
* Add windows1255.ts as a test helper. It encodes Hebrew text as Windows-1255 bytes.
* Add subtitleEncoding.test.ts to test decodeSubtitle and encodeSubtitle.
* Update sync test fixtures and SubtitleSyncer tests to read through decodeSubtitle. Add a SubtitleSyncer test for a Windows-1255 target file.
* Document subtitleEncoding.ts in the sync pipeline table in CLAUDE.md.